### PR TITLE
Allow manual workflow dispatching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 name: Build
 


### PR DESCRIPTION
Adds a button in GitHub to manually run the keymap builds when users would like to get up to date.

![image](https://user-images.githubusercontent.com/2270262/91874267-ff671400-ec47-11ea-82e4-0bb34f711948.png)
