### PR TITLE
Always cat the DTS file to the GA log for debugging.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
         id: west-build-SHIELD_NAME-left
         with:
           args: 'build "-s zmk/app -b BOARD_NAME -- -DSHIELD=SHIELD_NAME_left -DZMK_CONFIG=/github/workspace/config"'
+      - name: KEYBOARD_TITLE DTS File
+        if: ${{ always() }}
+        run: cat -n build/zephyr/BOARD_NAME.dts.pre.tmp
       - name: KEYBOARD_TITLE Left Kconfig file
         run: cat build/zephyr/.config | grep -v "^#" | grep -v "^$"
       - name: Rename zmk.uf2


### PR DESCRIPTION
I figure the most common issue will be "I made a typo what happened", so between this and the line number it gives you, should help narrow down the error.

This could go much further though, and look at parsing the output on failure and pulling out the line etc for the user. This is a nice quick way of letting users see the issues without needing to build though (I don't know if/how you can parse GA log output, I've not checked). More sophisicated checking would be better again (surprised if Zephyr doesn't have something to stop and say "I got stuck at X part on Y line").